### PR TITLE
change python version from 3.11.11 to 3.9.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /opt
 # Set environment variables
 USER root
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PYTHON_VERSION=3.11.11
+ARG PYTHON_VERSION=3.9.21
 
 # Update package list
 RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update -y


### PR DESCRIPTION
Changes Python version specified in `Dockerfile` from 3.11.11 to 3.9.21 due to abrupt closing of Pika-based RabbitMQ connections by the broker.