### PR TITLE
depends_on manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - ./:/opt/
     network_mode: "host"
     restart: "no"
+    depends_on:
+      - manager
 
   appender:
     container_name: sos_appender
@@ -35,6 +37,8 @@ services:
       - ./:/opt/
     network_mode: "host"
     restart: "no"
+    depends_on:
+      - manager
 
   simulator:
     container_name: sos_simulator
@@ -47,3 +51,5 @@ services:
       - ./:/opt/
     network_mode: "host"
     restart: "no"
+    depends_on:
+      - manager


### PR DESCRIPTION
- Updated `docker-compose.yml` to include the following for planner, appender, and simulator applications:
  ```yaml
  depends_on:
    - manager
  ```