### PR TITLE
bump from ubuntu 22.04 to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Set working directory
 WORKDIR /opt


### PR DESCRIPTION
- Updated Base Container OS: Upgraded the base container operating system from Ubuntu 22.04 to Ubuntu 24.04. This update aims to rule out any OS-level issues that might be contributing to the RabbitMQ connection drops.