### PR TITLE
Wait for a signal instead of busy-waiting

### DIFF
--- a/src/appender/main.py
+++ b/src/appender/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import signal
 import sys
 from datetime import timedelta,datetime
 import geopandas as gpd
@@ -473,8 +474,11 @@ def main():
     app.add_message_callback("planner", "selected_cells", environment.on_planner)
     app.add_message_callback("simulator", "simulator_daily", environment.on_simulator)
 
-    while True:
-        pass
+    # Wait for a signal rather than spinning. A bare `while True: pass` burns a
+    # CPU core for the whole run and cannot be interrupted, so the application
+    # could only ever be killed; signal.pause() returns once the shutdown
+    # handler has run, letting the process exit on its own.
+    signal.pause()
 
 if __name__ == "__main__":
     main()

--- a/src/simulator/main.py
+++ b/src/simulator/main.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import signal
 import sys
 from datetime import timedelta
 
@@ -87,8 +88,11 @@ def main():
     #     )
     # )
 
-    while True:
-        pass
+    # Wait for a signal rather than spinning. A bare `while True: pass` burns a
+    # CPU core for the whole run and cannot be interrupted, so the application
+    # could only ever be killed; signal.pause() returns once the shutdown
+    # handler has run, letting the process exit on its own.
+    signal.pause()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #130.

The appender and simulator ended `main()` with `while True: pass`. Both now wait with `signal.pause()`, as the planner already did.

## Two problems with the loop

**It occupies a CPU core per application.** A bare `while True: pass` never yields, so each of these two applications spins a core for the entire run while doing nothing.

**It cannot be interrupted.** A signal handler runs and returns, and the loop keeps spinning, so the process could only ever be killed.

The second was invisible while `nost_tools` ended `shut_down()` with `os._exit(0)`. As of nost-tools 3.6.0 the library lets the process exit on its own and only forces an exit as a fallback, thirty seconds later. Reaching that fallback means the process is killed rather than exiting, skipping the `atexit` handlers that release joblib's worker resources — which for the simulator is exactly what produces the leaked semaphore and folder warnings that library change was made to eliminate.

## The change

`import signal` in each file, and in place of the loop:

```python
# Wait for a signal rather than spinning. A bare `while True: pass` burns a
# CPU core for the whole run and cannot be interrupted, so the application
# could only ever be killed; signal.pause() returns once the shutdown
# handler has run, letting the process exit on its own.
signal.pause()
```

`nost_tools` installs the `SIGINT` and `SIGTERM` handlers and signals the process when a shutdown begins on a background thread, so the wait ends once teardown has finished.

## Verification

Run end to end against the full scenario. Manager, planner, appender and simulator all shut down, exit, and return to the prompt, with no leaked-object warnings from any of them.

## Not fixed here

The simulator dispatches `write_back_to_appender` on a daemon thread (`sos_sim/function.py:665-669`). Daemon threads are killed when the interpreter exits, so a stop command arriving mid-write can truncate the GeoJSON output or abandon the S3 upload, with nothing reporting it. That predates this change and is not made worse by it — the previous `os._exit(0)` gave such a write no grace at all — but it is a real exposure and deserves its own issue. The appender writes GeoJSON too and is worth checking for the same pattern.